### PR TITLE
Generalized HTTP request handling and fixed the case where HTTP errors are not handled

### DIFF
--- a/SurfaceDevCenterManager/DevCenterApi/Audience.cs
+++ b/SurfaceDevCenterManager/DevCenterApi/Audience.cs
@@ -7,9 +7,9 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
-namespace SurfaceDevCenterManager.DevCenterAPI
+namespace SurfaceDevCenterManager.DevCenterApi
 {
-    public class Audience
+    public class Audience : IArtifact
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/SurfaceDevCenterManager/DevCenterApi/DevCenterErrorDetails.cs
+++ b/SurfaceDevCenterManager/DevCenterApi/DevCenterErrorDetails.cs
@@ -5,7 +5,7 @@
 --*/
 using Newtonsoft.Json;
 
-namespace SurfaceDevCenterManager.DevCenterAPI
+namespace SurfaceDevCenterManager.DevCenterApi
 {
     public class DevCenterErrorDetails
     {

--- a/SurfaceDevCenterManager/DevCenterApi/DevCenterErrorReturn.cs
+++ b/SurfaceDevCenterManager/DevCenterApi/DevCenterErrorReturn.cs
@@ -5,7 +5,7 @@
 --*/
 using Newtonsoft.Json;
 
-namespace SurfaceDevCenterManager.DevCenterAPI
+namespace SurfaceDevCenterManager.DevCenterApi
 {
     public class DevCenterErrorReturn
     {

--- a/SurfaceDevCenterManager/DevCenterApi/DevCenterHandler.cs
+++ b/SurfaceDevCenterManager/DevCenterApi/DevCenterHandler.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 
-namespace SurfaceDevCenterManager.DevCenterAPI
+namespace SurfaceDevCenterManager.DevCenterApi
 {
     internal sealed class DevCenterHandler : IDisposable
     {
@@ -37,6 +37,132 @@ namespace SurfaceDevCenterManager.DevCenterAPI
             return returnUri.AbsoluteUri;
         }
 
+        private const string DefaultErrorcode = "InvalidInput";
+
+        /// <summary>
+        /// Invokes HDC service with the specified options
+        /// </summary>
+        /// <param name="method">HTTP method to use</param>
+        /// <param name="uri">URI of the service to invoke</param>
+        /// <param name="input">Content used as the request options</param>
+        /// <param name="processContent">Process the service return content</param>
+        /// <returns>Dev Center response with either an error or null if the operation was successful</returns>
+        public async Task<DevCenterErrorDetails> InvokeHdcService(
+            HttpMethod method, string uri, object input, Action<string> processContent)
+        {
+            using (HttpClient client = new HttpClient(AuthHandler, false))
+            {
+                Uri restApi = new Uri(uri);
+
+                HttpResponseMessage infoResult = null;
+                if (HttpMethod.Get == method)
+                {
+                    infoResult = await client.GetAsync(restApi);
+                }
+                else if (HttpMethod.Post == method)
+                {
+                    string json = JsonConvert.SerializeObject(input == null ? new object() : input);
+                    StringContent postContent = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+                    infoResult = await client.PostAsync(restApi, postContent);
+                }
+                else
+                {
+                    return new DevCenterErrorDetails
+                    {
+                        Code = DefaultErrorcode,
+                        Message = "Unsupported HTTP method"
+                    };
+                }
+
+                string content = await infoResult.Content.ReadAsStringAsync();
+                if (infoResult.IsSuccessStatusCode)
+                {
+                    if (processContent != null)
+                    {
+                        processContent(content);
+                    }
+
+                    return null;
+                }
+
+                DevCenterErrorReturn reterr = JsonConvert.DeserializeObject<DevCenterErrorReturn>(content);
+                // reterr can be null when there is HTTP error
+                if (reterr == null)
+                {
+                    return new DevCenterErrorDetails
+                    {
+                        Code = infoResult.StatusCode.ToString("D"),
+                        Message = infoResult.ReasonPhrase
+                    };
+                }
+
+                if (reterr.Error != null)
+                {
+                    return reterr.Error;
+                }
+
+                return new DevCenterErrorDetails
+                {
+                    Code = reterr.StatusCode,
+                    Message = reterr.Message
+                };
+            }
+        }
+
+        /// <summary>
+        /// Invokes HDC service with the specified options
+        /// </summary>
+        /// <param name="method">HTTP method to use</param>
+        /// <param name="uri">URI of the service to invoke</param>
+        /// <param name="input">Options for the new artifact to be generated</param>
+        /// <param name="isMany">Whether the result has a single entity or multiple</param>
+        /// <returns>Dev Center response with either an error or an artifact if created/queried successfully</returns>
+        public async Task<DevCenterResponse<Output>> InvokeHdcService<Output>(
+            HttpMethod method, string uri, object input, bool isMany) where Output : IArtifact
+        {
+            DevCenterResponse<Output> retval = new DevCenterResponse<Output>();
+            retval.Error = await InvokeHdcService(method, uri, input, (content) => 
+            {
+                if (isMany)
+                {
+                    Response<Output> ret = JsonConvert.DeserializeObject<Response<Output>>(content);
+                    retval.ReturnValue = ret.Value;
+                }
+                else
+                {
+                    Output ret = JsonConvert.DeserializeObject<Output>(content);
+                    if (ret.Id != null)
+                    {
+                        retval.ReturnValue = new List<Output> { ret };
+                    }
+                }
+            });
+
+            return retval;
+        }
+
+        /// <summary>
+        /// Invokes HDC GET request with the specified options
+        /// </summary>
+        /// <param name="uri">URI of the service to invoke</param>
+        /// <param name="isMany">Whether the result has a single entity or multiple</param>
+        /// <returns>Dev Center response with either an error or a list of artifacts if queried successfully</returns>
+        public async Task<DevCenterResponse<Output>> HdcGet<Output>(string uri, bool isMany) where Output : IArtifact
+        {
+            return await InvokeHdcService<Output>(HttpMethod.Get, uri, null, isMany);
+        }
+
+        /// <summary>
+        /// Invokes HDC POST request with the specified options
+        /// </summary>
+        /// <param name="uri">URI of the service to invoke</param>
+        /// <param name="input">Options for the new artifact to be generated</param>
+        /// <returns>Dev Center response with either an error or an artifact if created successfully</returns>
+        public async Task<DevCenterResponse<Output>> HdcPost<Output>(string uri, object input) where Output : IArtifact
+        {
+            return await InvokeHdcService<Output>(HttpMethod.Post, uri, input, false);
+        }
+
         private const string DevCenterProductsUrl = "/hardware/products";
 
         /// <summary>
@@ -46,366 +172,128 @@ namespace SurfaceDevCenterManager.DevCenterAPI
         /// <returns>Dev Center response with either an error or a Product if created successfully</returns>
         public async Task<DevCenterResponse<Product>> NewProduct(NewProduct input)
         {
-            DevCenterResponse<Product> retval = null;
-            string NewProductsUrl = GetDevCenterBaseUrl() + DevCenterProductsUrl;
-
-            using (HttpClient client = new HttpClient(AuthHandler, false))
-            {
-                Uri restApi = new Uri(NewProductsUrl);
-
-                string json = JsonConvert.SerializeObject(input);
-                StringContent postcontent = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
-
-                HttpResponseMessage infoResult = await client.PostAsync(restApi, postcontent);
-
-                string content = await infoResult.Content.ReadAsStringAsync();
-
-                retval = new DevCenterResponse<Product>();
-                if (infoResult.IsSuccessStatusCode)
-                {
-                    Product ret = JsonConvert.DeserializeObject<Product>(content);
-                    if (ret.Id != null)
-                    {
-                        retval.ReturnValue = new List<Product>
-                        {
-                            ret
-                        };
-                    }
-                }
-                else
-                {
-                    retval.Error = DeserializeDevCenterError(content);
-                }
-            }
-
-            return retval;
+            string newProductsUrl = GetDevCenterBaseUrl() + DevCenterProductsUrl;
+            return await HdcPost<Product>(newProductsUrl, input);
         }
 
         /// <summary>
         /// Gets a list of products or a specific product from HWDC
         /// </summary>
-        /// <param name="ProductId">Gets all products if null otherwise retrieves the specified product</param>
+        /// <param name="productId">Gets all products if null otherwise retrieves the specified product</param>
         /// <returns>Dev Center response with either an error or a Product if queried successfully</returns>
-        public async Task<DevCenterResponse<Product>> GetProducts(string ProductId = null)
+        public async Task<DevCenterResponse<Product>> GetProducts(string productId = null)
         {
-            DevCenterResponse<Product> retval = null;
-            string GetProductsUrl = GetDevCenterBaseUrl() + DevCenterProductsUrl;
+            string getProductsUrl = GetDevCenterBaseUrl() + DevCenterProductsUrl;
 
-            if (ProductId != null)
+            bool isMany = String.IsNullOrEmpty(productId);
+            if (!isMany)
             {
-                GetProductsUrl += "/" + Uri.EscapeDataString(ProductId);
+                getProductsUrl += "/" + Uri.EscapeDataString(productId);
             }
 
-            using (HttpClient client = new HttpClient(AuthHandler, false))
-            {
-                Uri restApi = new Uri(GetProductsUrl);
-
-                HttpResponseMessage infoResult = await client.GetAsync(restApi);
-
-                string content = await infoResult.Content.ReadAsStringAsync();
-
-                retval = new DevCenterResponse<Product>();
-                if (infoResult.IsSuccessStatusCode)
-                {
-                    if (ProductId != null)
-                    {
-                        Product ret = JsonConvert.DeserializeObject<Product>(content);
-                        if (ret.Id != null)
-                        {
-                            retval.ReturnValue = new List<Product>
-                            {
-                                ret
-                            };
-                        }
-                    }
-                    else
-                    {
-                        Response<Product> ret = JsonConvert.DeserializeObject<Response<Product>>(content);
-                        retval.ReturnValue = ret.Value;
-                    }
-                }
-                else
-                {
-                    retval.Error = DeserializeDevCenterError(content);
-                }
-            }
-
-            return retval;
+            return await HdcGet<Product>(getProductsUrl, isMany);
         }
 
         private const string DevCenterProductSubmissionUrl = "/hardware/products/{0}/submissions";
+
         /// <summary>
         /// Creates a new Submission in HWDC with the specified options
         /// </summary>
-        /// <param name="ProductId">Specifiy the Product ID for this Submission</param>
+        /// <param name="productId">Specifiy the Product ID for this Submission</param>
         /// <param name="submissionInfo">Options for the new Submission to be generated</param>
         /// <returns>Dev Center response with either an error or a Submission if created successfully</returns>
-        public async Task<DevCenterResponse<Submission>> NewSubmission(string ProductId, NewSubmission submissionInfo)
+        public async Task<DevCenterResponse<Submission>> NewSubmission(string productId, NewSubmission submissionInfo)
         {
-            DevCenterResponse<Submission> retval = null;
-            string NewProductSubmissionUrl = GetDevCenterBaseUrl() + string.Format(DevCenterProductSubmissionUrl, Uri.EscapeDataString(ProductId));
-
-            using (HttpClient client = new HttpClient(AuthHandler, false))
-            {
-                Uri restApi = new Uri(NewProductSubmissionUrl);
-
-                string json = JsonConvert.SerializeObject(submissionInfo);
-                StringContent postcontent = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
-
-                HttpResponseMessage infoResult = await client.PostAsync(restApi, postcontent);
-
-                string content = await infoResult.Content.ReadAsStringAsync();
-
-                retval = new DevCenterResponse<Submission>();
-                if (infoResult.IsSuccessStatusCode)
-                {
-                    Submission ret = JsonConvert.DeserializeObject<Submission>(content);
-                    if (ret.Id != null)
-                    {
-                        retval.ReturnValue = new List<Submission>
-                        {
-                            ret
-                        };
-                    }
-                }
-                else
-                {
-                    retval.Error = DeserializeDevCenterError(content);
-                }
-
-            }
-
-            return retval;
+            string newProductSubmissionUrl = GetDevCenterBaseUrl() + 
+                string.Format(DevCenterProductSubmissionUrl, Uri.EscapeDataString(productId));
+            return await HdcPost<Submission>(newProductSubmissionUrl, submissionInfo);
         }
 
         /// <summary>
         /// Gets a list of submissions or a specific submission from HWDC
         /// </summary>
-        /// <param name="ProductId">Specifiy the Product ID for this Submission</param>
-        /// <param name="SubmissionId">Gets all submissions if null otherwise retrieves the specified submission</param>
+        /// <param name="productId">Specifiy the Product ID for this Submission</param>
+        /// <param name="submissionId">Gets all submissions if null otherwise retrieves the specified submission</param>
         /// <returns>Dev Center response with either an error or a Submission if queried successfully</returns>
-        public async Task<DevCenterResponse<Submission>> GetSubmission(string ProductId, string SubmissionId = null)
+        public async Task<DevCenterResponse<Submission>> GetSubmission(string productId, string submissionId = null)
         {
-            DevCenterResponse<Submission> retval = null;
-            string GetProductSubmissionUrl = GetDevCenterBaseUrl() + string.Format(DevCenterProductSubmissionUrl, Uri.EscapeDataString(ProductId));
+            string getProductSubmissionUrl = GetDevCenterBaseUrl() + 
+                string.Format(DevCenterProductSubmissionUrl, Uri.EscapeDataString(productId));
 
-            if (SubmissionId != null)
+            bool isMany = String.IsNullOrEmpty(submissionId);
+            if (!isMany)
             {
-                GetProductSubmissionUrl += "/" + Uri.EscapeDataString(SubmissionId);
+                getProductSubmissionUrl += "/" + Uri.EscapeDataString(submissionId);
             }
 
-            using (HttpClient client = new HttpClient(AuthHandler, false))
-            {
-                Uri restApi = new Uri(GetProductSubmissionUrl);
-
-                HttpResponseMessage infoResult = await client.GetAsync(restApi);
-
-                string content = await infoResult.Content.ReadAsStringAsync();
-
-                retval = new DevCenterResponse<Submission>();
-                if (infoResult.IsSuccessStatusCode)
-                {
-                    if (SubmissionId != null)
-                    {
-                        Submission ret = JsonConvert.DeserializeObject<Submission>(content);
-                        if (ret.Id != null)
-                        {
-                            retval.ReturnValue = new List<Submission>
-                            {
-                                ret
-                            };
-                        }
-                    }
-                    else
-                    {
-                        Response<Submission> ret = JsonConvert.DeserializeObject<Response<Submission>>(content);
-                        retval.ReturnValue = ret.Value;
-                    }
-                }
-                else
-                {
-                    retval.Error = DeserializeDevCenterError(content);
-                }
-            }
-
-            return retval;
+            return await HdcGet<Submission>(getProductSubmissionUrl, isMany);
         }
 
         /// <summary>
         /// Commits a Submission in HWDC
         /// </summary>
-        /// <param name="ProductId">Specifiy the Product ID for the Submission to commit</param>
-        /// <param name="SubmissionId">Specifiy the Submission ID for the Submission to commit</param>
+        /// <param name="productId">Specifiy the Product ID for the Submission to commit</param>
+        /// <param name="submissionId">Specifiy the Submission ID for the Submission to commit</param>
         /// <returns>Dev Center response with either an error or a true if comitted successfully</returns>
-        public async Task<bool> CommitSubmission(string ProductId, string SubmissionId)
+        public async Task<bool> CommitSubmission(string productId, string submissionId)
         {
-            bool retval = false;
-            string CommitProductSubmissionUrl = GetDevCenterBaseUrl() + string.Format(DevCenterProductSubmissionUrl, Uri.EscapeDataString(ProductId)) +
-                                                "/" + Uri.EscapeDataString(SubmissionId) + "/commit";
-
-            using (HttpClient client = new HttpClient(AuthHandler, false))
-            {
-                Uri restApi = new Uri(CommitProductSubmissionUrl);
-
-                StringContent postcontent = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
-
-                HttpResponseMessage infoResult = await client.PostAsync(restApi, postcontent);
-
-                string content = await infoResult.Content.ReadAsStringAsync();
-
-                retval = infoResult.IsSuccessStatusCode;
-            }
-
-            return retval;
+            string commitProductSubmissionUrl = GetDevCenterBaseUrl() +
+                string.Format(DevCenterProductSubmissionUrl, Uri.EscapeDataString(productId)) +
+                "/" + Uri.EscapeDataString(submissionId) + "/commit";
+            DevCenterErrorDetails error = await InvokeHdcService(HttpMethod.Post, commitProductSubmissionUrl, null, null);
+            return error == null;
         }
 
         private const string DevCenterShippingLabelUrl = "/hardware/products/{0}/submissions/{1}/shippingLabels";
+
         /// <summary>
         /// Creates a new Shipping Label in HWDC with the specified options
         /// </summary>
-        /// <param name="ProductId">Specifiy the Product ID for this Shipping Label</param>
-        /// <param name="SubmissionId">Specifiy the Submission ID for this Shipping Label</param>
+        /// <param name="productId">Specifiy the Product ID for this Shipping Label</param>
+        /// <param name="submissionId">Specifiy the Submission ID for this Shipping Label</param>
         /// <param name="shippingLabelInfo">Options for the new Shipping Label to be generated</param>
         /// <returns>Dev Center response with either an error or a ShippingLabel if created successfully</returns>
-        public async Task<DevCenterResponse<ShippingLabel>> NewShippingLabel(string ProductId, string SubmissionId, NewShippingLabel shippingLabelInfo)
+        public async Task<DevCenterResponse<ShippingLabel>> NewShippingLabel(
+            string productId, string submissionId, NewShippingLabel shippingLabelInfo)
         {
-            DevCenterResponse<ShippingLabel> retval = null;
-            string ShippingLabelUrl = GetDevCenterBaseUrl() + string.Format(DevCenterShippingLabelUrl, Uri.EscapeDataString(ProductId), Uri.EscapeDataString(SubmissionId));
-
-            using (HttpClient client = new HttpClient(AuthHandler, false))
-            {
-                Uri restApi = new Uri(ShippingLabelUrl);
-
-                string json = JsonConvert.SerializeObject(shippingLabelInfo);
-                StringContent postcontent = new StringContent(json,
-                                                              System.Text.Encoding.UTF8,
-                                                              "application/json");
-
-                HttpResponseMessage infoResult = await client.PostAsync(restApi, postcontent);
-
-                string content = await infoResult.Content.ReadAsStringAsync();
-
-                retval = new DevCenterResponse<ShippingLabel>();
-                if (infoResult.IsSuccessStatusCode)
-                {
-                    ShippingLabel ret = JsonConvert.DeserializeObject<ShippingLabel>(content);
-                    if (ret.Id != null)
-                    {
-                        retval.ReturnValue = new List<ShippingLabel>
-                        {
-                            ret
-                        };
-                    }
-                }
-                else
-                {
-                    retval.Error = DeserializeDevCenterError(content);
-                }
-            }
-
-            return retval;
+            string shippingLabelUrl = GetDevCenterBaseUrl() +
+                string.Format(DevCenterShippingLabelUrl, Uri.EscapeDataString(productId), Uri.EscapeDataString(submissionId));
+            return await HdcPost<ShippingLabel>(shippingLabelUrl, shippingLabelInfo);
         }
 
         /// <summary>
         /// Gets a list of shipping labels or a specific shipping label from HWDC
         /// </summary>
-        /// <param name="ProductId">Specifiy the Product ID for this Shipping Label</param>
-        /// <param name="SubmissionId">Specifiy the Submission ID for this Shipping Label</param>
-        /// <param name="ShippingLabelId">Gets all Shipping Labels if null otherwise retrieves the specified Shipping Label</param>
+        /// <param name="productId">Specifiy the Product ID for this Shipping Label</param>
+        /// <param name="submissionId">Specifiy the Submission ID for this Shipping Label</param>
+        /// <param name="shippingLabelId">Gets all Shipping Labels if null otherwise retrieves the specified Shipping Label</param>
         /// <returns>Dev Center response with either an error or a ShippingLabel if queried successfully</returns>
-        public async Task<DevCenterResponse<ShippingLabel>> GetShippingLabels(string ProductId, string SubmissionId, string ShippingLabelId = null)
+        public async Task<DevCenterResponse<ShippingLabel>> GetShippingLabels(
+            string productId, string submissionId, string shippingLabelId = null)
         {
-            DevCenterResponse<ShippingLabel> retval = null;
-            string GetShippingLabelUrl = GetDevCenterBaseUrl() + string.Format(DevCenterShippingLabelUrl, Uri.EscapeDataString(ProductId), Uri.EscapeDataString(SubmissionId));
+            string getShippingLabelUrl = GetDevCenterBaseUrl() +
+                string.Format(DevCenterShippingLabelUrl, Uri.EscapeDataString(productId), Uri.EscapeDataString(submissionId));
 
-            if (ShippingLabelId != null)
+            bool isMany = String.IsNullOrEmpty(shippingLabelId);
+            if (!isMany)
             {
-                GetShippingLabelUrl += "/" + Uri.EscapeDataString(ShippingLabelId);
+                getShippingLabelUrl += "/" + Uri.EscapeDataString(shippingLabelId);
             }
 
-            GetShippingLabelUrl += @"?includeTargetingInfo=true";
-
-            using (HttpClient client = new HttpClient(AuthHandler, false))
-            {
-                Uri restApi = new Uri(GetShippingLabelUrl);
-
-                HttpResponseMessage infoResult = await client.GetAsync(restApi);
-
-                string content = await infoResult.Content.ReadAsStringAsync();
-
-                retval = new DevCenterResponse<ShippingLabel>();
-                if (infoResult.IsSuccessStatusCode)
-                {
-                    //dynamic jObj = JsonConvert.DeserializeObject(content);
-                    if (ShippingLabelId != null)
-                    {
-                        ShippingLabel ret = JsonConvert.DeserializeObject<ShippingLabel>(content);
-                        retval.ReturnValue = new List<ShippingLabel>
-                        {
-                            ret
-                        };
-                    }
-                    else
-                    {
-                        Response<ShippingLabel> ret = JsonConvert.DeserializeObject<Response<ShippingLabel>>(content);
-                        retval.ReturnValue = ret.Value;
-                    }
-                }
-                else
-                {
-                    retval.Error = DeserializeDevCenterError(content);
-                }
-            }
-
-            return retval;
-        }
-
-        private DevCenterErrorDetails DeserializeDevCenterError(string content)
-        {
-            DevCenterErrorReturn reterr = JsonConvert.DeserializeObject<DevCenterErrorReturn>(content);
-            if (reterr.Error == null && reterr.StatusCode != null)
-            {
-                reterr.Error = new DevCenterErrorDetails()
-                {
-                    Code = reterr.StatusCode,
-                    Message = reterr.Message
-                };
-            }
-            return reterr.Error;
+            getShippingLabelUrl += @"?includeTargetingInfo=true";
+            return await HdcGet<ShippingLabel>(getShippingLabelUrl, isMany);
         }
 
         private const string DevCenterAudienceUrl = "/hardware/audiences";
+
         /// <summary>
         /// Gets a list of valid audiences from HWDC
         /// </summary>
         /// <returns>Dev Center response with either an error or a Audience if queried successfully</returns>
         public async Task<DevCenterResponse<Audience>> GetAudiences()
         {
-            DevCenterResponse<Audience> retval = null;
-            string GetAudienceUrl = GetDevCenterBaseUrl() + DevCenterAudienceUrl;
-
-            using (HttpClient client = new HttpClient(AuthHandler, false))
-            {
-                Uri restApi = new Uri(GetAudienceUrl);
-
-                HttpResponseMessage infoResult = await client.GetAsync(restApi);
-
-                string content = await infoResult.Content.ReadAsStringAsync();
-
-                retval = new DevCenterResponse<Audience>();
-                if (infoResult.IsSuccessStatusCode)
-                {
-                    Response<Audience> ret = JsonConvert.DeserializeObject<Response<Audience>>(content);
-                    retval.ReturnValue = ret.Value;
-                }
-                else
-                {
-                    retval.Error = DeserializeDevCenterError(content);
-                }
-
-            }
-
-            return retval;
+            string getAudienceUrl = GetDevCenterBaseUrl() + DevCenterAudienceUrl;
+            return await HdcGet<Audience>(getAudienceUrl, true);
         }
 
         public void Dispose()

--- a/SurfaceDevCenterManager/DevCenterApi/Download.cs
+++ b/SurfaceDevCenterManager/DevCenterApi/Download.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
-namespace SurfaceDevCenterManager.DevCenterAPI
+namespace SurfaceDevCenterManager.DevCenterApi
 {
     public class Download
     {

--- a/SurfaceDevCenterManager/DevCenterApi/DriverMetadata.cs
+++ b/SurfaceDevCenterManager/DevCenterApi/DriverMetadata.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace SurfaceDevCenterManager.DevCenterAPI
+namespace SurfaceDevCenterManager.DevCenterApi
 {
     public class DriverMetadataHWID
     {

--- a/SurfaceDevCenterManager/DevCenterApi/IArtifact.cs
+++ b/SurfaceDevCenterManager/DevCenterApi/IArtifact.cs
@@ -3,13 +3,11 @@
 
     Licensed under the MIT license.  See LICENSE file in the project root for full license information.  
 --*/
-using System.Collections.Generic;
 
 namespace SurfaceDevCenterManager.DevCenterApi
 {
-    public class DevCenterResponse<T>
+    public interface IArtifact
     {
-        public DevCenterErrorDetails Error { get; set; }
-        public List<T> ReturnValue { get; set; }
+        string Id { get; set; }
     }
 }

--- a/SurfaceDevCenterManager/DevCenterApi/Link.cs
+++ b/SurfaceDevCenterManager/DevCenterApi/Link.cs
@@ -6,7 +6,7 @@
 using Newtonsoft.Json;
 using System;
 
-namespace SurfaceDevCenterManager.DevCenterAPI
+namespace SurfaceDevCenterManager.DevCenterApi
 {
     public class Link
     {

--- a/SurfaceDevCenterManager/DevCenterApi/Product.cs
+++ b/SurfaceDevCenterManager/DevCenterApi/Product.cs
@@ -8,9 +8,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 
-namespace SurfaceDevCenterManager.DevCenterAPI
+namespace SurfaceDevCenterManager.DevCenterApi
 {
-    public class Product
+    public class Product : IArtifact
     {
         [JsonProperty("id")]
         public string Id { get; set; }
@@ -157,5 +157,4 @@ namespace SurfaceDevCenterManager.DevCenterAPI
         [JsonProperty("testHarness")]
         public string TestHarness { get; set; }
     }
-
 }

--- a/SurfaceDevCenterManager/DevCenterApi/Response.cs
+++ b/SurfaceDevCenterManager/DevCenterApi/Response.cs
@@ -6,7 +6,7 @@
 using Newtonsoft.Json;
 using System.Collections.Generic;
 
-namespace SurfaceDevCenterManager.DevCenterAPI
+namespace SurfaceDevCenterManager.DevCenterApi
 {
     public class Response<T>
     {

--- a/SurfaceDevCenterManager/DevCenterApi/ShippingLabel.cs
+++ b/SurfaceDevCenterManager/DevCenterApi/ShippingLabel.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
-namespace SurfaceDevCenterManager.DevCenterAPI
+namespace SurfaceDevCenterManager.DevCenterApi
 {
     public class AdditionalInfoForMsApproval
     {
@@ -113,7 +113,7 @@ namespace SurfaceDevCenterManager.DevCenterAPI
         public string Destination { get; set; }
     }
 
-    public class ShippingLabel
+    public class ShippingLabel : IArtifact
     {
         [JsonProperty("id")]
         public string Id { get; set; }
@@ -181,7 +181,5 @@ namespace SurfaceDevCenterManager.DevCenterAPI
             }
             Console.WriteLine();
         }
-
     }
-
 }

--- a/SurfaceDevCenterManager/DevCenterApi/Submission.cs
+++ b/SurfaceDevCenterManager/DevCenterApi/Submission.cs
@@ -7,10 +7,9 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
-namespace SurfaceDevCenterManager.DevCenterAPI
+namespace SurfaceDevCenterManager.DevCenterApi
 {
-
-    public class Submission
+    public class Submission : IArtifact
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/SurfaceDevCenterManager/DevCenterApi/WorkflowStatus.cs
+++ b/SurfaceDevCenterManager/DevCenterApi/WorkflowStatus.cs
@@ -8,7 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace SurfaceDevCenterManager.DevCenterAPI
+namespace SurfaceDevCenterManager.DevCenterApi
 {
     public class WorkflowStatus
     {

--- a/SurfaceDevCenterManager/Program.cs
+++ b/SurfaceDevCenterManager/Program.cs
@@ -5,7 +5,7 @@
 --*/
 using Mono.Options;
 using Newtonsoft.Json;
-using SurfaceDevCenterManager.DevCenterAPI;
+using SurfaceDevCenterManager.DevCenterApi;
 using SurfaceDevCenterManager.Utility;
 using System;
 using System.Collections.Generic;
@@ -169,7 +169,7 @@ namespace SurfaceDevCenterManager
                 if (DevCenterHWSubmissionType.Product == createInput.CreateType)
                 {
                     DevCenterResponse<Product> ret = await api.NewProduct(createInput.CreateProduct);
-                    if (ret == null || ret.Error != null)
+                    if (ret.Error != null)
                     {
                         Console.WriteLine("ERROR");
                         Console.WriteLine(ret.Error.Code ?? "");
@@ -194,7 +194,7 @@ namespace SurfaceDevCenterManager
                     {
                         Console.WriteLine("> Creating Submission");
                         DevCenterResponse<Submission> ret = await api.NewSubmission(ProductId, createInput.CreateSubmission);
-                        if (ret == null || ret.Error != null)
+                        if (ret.Error != null)
                         {
                             Console.WriteLine("ERROR");
                             Console.WriteLine(ret.Error.Code ?? "");
@@ -227,7 +227,7 @@ namespace SurfaceDevCenterManager
                         string tmpfile = System.IO.Path.GetTempFileName();
 
                         DevCenterResponse<Submission> retSubmission = await api.GetSubmission(ProductId, SubmissionId);
-                        if (retSubmission == null || retSubmission.Error != null)
+                        if (retSubmission.Error != null)
                         {
                             Console.WriteLine("ERROR");
                             Console.WriteLine(retSubmission.Error.Code ?? "");
@@ -279,7 +279,7 @@ namespace SurfaceDevCenterManager
 
                         Console.WriteLine("> Creating Shipping Label");
                         DevCenterResponse<ShippingLabel> ret = await api.NewShippingLabel(ProductId, SubmissionId, createInput.CreateShippingLabel);
-                        if (ret == null || ret.Error != null)
+                        if (ret.Error != null)
                         {
                             Console.WriteLine("ERROR");
                             Console.WriteLine(ret.Error.Code ?? "");
@@ -336,7 +336,7 @@ namespace SurfaceDevCenterManager
                     case DevCenterHWSubmissionType.Product:
                         {
                             DevCenterResponse<Product> ret = await api.GetProducts(ProductId);
-                            if (ret == null || ret.Error != null)
+                            if (ret.Error != null)
                             {
                                 Console.WriteLine("ERROR");
                                 Console.WriteLine(ret.Error.Code ?? "");
@@ -345,7 +345,7 @@ namespace SurfaceDevCenterManager
                             }
                             else
                             {
-                                List<DevCenterAPI.Product> products = ret.ReturnValue;
+                                List<Product> products = ret.ReturnValue;
                                 foreach (Product product in products)
                                 {
                                     product.Dump();
@@ -356,7 +356,7 @@ namespace SurfaceDevCenterManager
                     case DevCenterHWSubmissionType.Submission:
                         {
                             DevCenterResponse<Submission> ret = await api.GetSubmission(ProductId, SubmissionId);
-                            if (ret == null || ret.Error != null)
+                            if (ret.Error != null)
                             {
                                 Console.WriteLine("ERROR");
                                 Console.WriteLine(ret.Error.Code ?? "");
@@ -365,7 +365,7 @@ namespace SurfaceDevCenterManager
                             }
                             else
                             {
-                                List<DevCenterAPI.Submission> submissions = ret.ReturnValue;
+                                List<Submission> submissions = ret.ReturnValue;
                                 foreach (Submission submission in submissions)
                                 {
                                     submission.Dump();
@@ -376,7 +376,7 @@ namespace SurfaceDevCenterManager
                     case DevCenterHWSubmissionType.ShippingLabel:
                         {
                             DevCenterResponse<ShippingLabel> ret = await api.GetShippingLabels(ProductId, SubmissionId, ShippingLabelId);
-                            if (ret == null || ret.Error != null)
+                            if (ret.Error != null)
                             {
                                 Console.WriteLine("ERROR");
                                 Console.WriteLine(ret.Error.Code ?? "");
@@ -434,7 +434,7 @@ namespace SurfaceDevCenterManager
                 {
                     Console.WriteLine("> Fetch Submission Info");
                     DevCenterResponse<Submission> ret = await api.GetSubmission(ProductId, SubmissionId);
-                    if (ret == null || ret.Error != null)
+                    if (ret.Error != null)
                     {
                         Console.WriteLine("ERROR");
                         Console.WriteLine(ret.Error.Code ?? "");
@@ -474,7 +474,7 @@ namespace SurfaceDevCenterManager
                 {
                     Console.WriteLine("> Fetch Submission Info");
                     DevCenterResponse<Submission> ret = await api.GetSubmission(ProductId, SubmissionId);
-                    if (ret == null || ret.Error != null)
+                    if (ret.Error != null)
                     {
                         Console.WriteLine("ERROR");
                         Console.WriteLine(ret.Error.Code ?? "");
@@ -521,7 +521,7 @@ namespace SurfaceDevCenterManager
                 {
                     Console.WriteLine("> Fetch Submission Info");
                     DevCenterResponse<Submission> ret = await api.GetSubmission(ProductId, SubmissionId);
-                    if (ret == null || ret.Error != null)
+                    if (ret.Error != null)
                     {
                         Console.WriteLine("ERROR");
                         Console.WriteLine(ret.Error.Code ?? "");
@@ -569,7 +569,7 @@ namespace SurfaceDevCenterManager
                         if (ShippingLabelId == null)
                         {
                             DevCenterResponse<Submission> ret = await api.GetSubmission(ProductId, SubmissionId);
-                            if (ret == null || ret.Error != null)
+                            if (ret.Error != null)
                             {
                                 Console.WriteLine("ERROR");
                                 Console.WriteLine(ret.Error.Code ?? "");
@@ -578,7 +578,7 @@ namespace SurfaceDevCenterManager
                                 retval = ErrorCodes.WAIT_GET_SUBMISSION_API_FAILED;
                                 break;
                             }
-                            List<DevCenterAPI.Submission> submissions = ret.ReturnValue;
+                            List<Submission> submissions = ret.ReturnValue;
                             Submission sub = submissions[0];
 
                             if (!done)
@@ -644,7 +644,7 @@ namespace SurfaceDevCenterManager
                         else
                         {
                             DevCenterResponse<ShippingLabel> ret = await api.GetShippingLabels(ProductId, SubmissionId, ShippingLabelId);
-                            if (ret == null || ret.Error != null)
+                            if (ret.Error != null)
                             {
                                 Console.WriteLine("ERROR");
                                 Console.WriteLine(ret.Error.Code ?? "");
@@ -688,7 +688,7 @@ namespace SurfaceDevCenterManager
                 Console.WriteLine("> Audience Option");
 
                 DevCenterResponse<Audience> ret = await api.GetAudiences();
-                if (ret == null || ret.Error != null)
+                if (ret.Error != null)
                 {
                     Console.WriteLine("ERROR");
                     Console.WriteLine(ret.Error.Code ?? "");

--- a/SurfaceDevCenterManager/SurfaceDevCenterManager.csproj
+++ b/SurfaceDevCenterManager/SurfaceDevCenterManager.csproj
@@ -62,6 +62,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DevCenterApi\IArtifact.cs" />
     <Compile Include="DevCenterApi\DevCenterErrorDetails.cs" />
     <Compile Include="DevCenterApi\DevCenterErrorReturn.cs" />
     <Compile Include="DevCenterApi\DevCenterResponse.cs" />


### PR DESCRIPTION
- Generalize the HTTP handling so it's in a single place instead of across multiple methods
- Rename the namespace to match the directory name
- Handle HTTP errors 
- Minor fix to remove the null check on the DeviceCenterResponse, which will not work when it's null, and since the API will never return a null so this check is removed.