### PR TITLE
Increase timeout

### DIFF
--- a/SurfaceDevCenterManager/DevCenterApi/DevCenterErrorDetails.cs
+++ b/SurfaceDevCenterManager/DevCenterApi/DevCenterErrorDetails.cs
@@ -18,6 +18,9 @@ namespace SurfaceDevCenterManager.DevCenterApi
 
         [JsonProperty("validationErrors")]
         public List<DevCenterErrorValidationErrorEntry> ValidationErrors;
+
+        [JsonProperty("httpErrorCode")]
+        public int HttpErrorCode { get; set; }
     }
 
     public class DevCenterErrorValidationErrorEntry

--- a/SurfaceDevCenterManager/DevCenterApi/DevCenterErrorReturn.cs
+++ b/SurfaceDevCenterManager/DevCenterApi/DevCenterErrorReturn.cs
@@ -17,5 +17,8 @@ namespace SurfaceDevCenterManager.DevCenterApi
 
         [JsonProperty("message")]
         public string Message { get; set; }
+
+        [JsonProperty("httpErrorCode")]
+        public int HttpErrorCode { get; set; }
     }
 }

--- a/SurfaceDevCenterManager/DevCenterApi/DevCenterHandler.cs
+++ b/SurfaceDevCenterManager/DevCenterApi/DevCenterHandler.cs
@@ -55,6 +55,8 @@ namespace SurfaceDevCenterManager.DevCenterApi
             HttpMethod method, string uri, object input, Action<string> processContent)
         {
             int retries = 0;
+            DevCenterErrorReturn reterr = null;
+
             using (HttpClient client = new HttpClient(AuthHandler, false))
             {
                 client.Timeout = HttpTimeout;
@@ -64,6 +66,7 @@ namespace SurfaceDevCenterManager.DevCenterApi
                 {
                     return new DevCenterErrorDetails
                     {
+                        HttpErrorCode = -1,
                         Code = DefaultErrorcode,
                         Message = "Unsupported HTTP method"
                     };
@@ -74,6 +77,7 @@ namespace SurfaceDevCenterManager.DevCenterApi
                 while (retries < MAX_RETRIES)
                 {
                     retries++;
+                    reterr = null;
 
                     try
                     {
@@ -102,40 +106,46 @@ namespace SurfaceDevCenterManager.DevCenterApi
                         }
                     }
 
-                    break;
-                }
-
-                string content = await infoResult.Content.ReadAsStringAsync();
-                if (infoResult.IsSuccessStatusCode)
-                {
-                    processContent?.Invoke(content);
-                    return null;
-                }
-
-                DevCenterErrorReturn reterr = null;
-
-                try
-                {
-                    reterr = JsonConvert.DeserializeObject<DevCenterErrorReturn>(content);
-                }
-                catch (Newtonsoft.Json.JsonReaderException)
-                {
-                    // Error is in bad format, return raw
-                    reterr = new DevCenterErrorReturn()
+                    string content = await infoResult.Content.ReadAsStringAsync();
+                    if (infoResult.IsSuccessStatusCode)
                     {
-                        StatusCode = infoResult.StatusCode.ToString(),
-                        Message = content
-                    };
-                }
+                        processContent?.Invoke(content);
+                        return null;
+                    }
 
-                // reterr can be null when there is HTTP error
-                if (reterr == null)
-                {
-                    return new DevCenterErrorDetails
+                    try
                     {
-                        Code = infoResult.StatusCode.ToString("D"),
-                        Message = infoResult.ReasonPhrase
-                    };
+                        reterr = JsonConvert.DeserializeObject<DevCenterErrorReturn>(content);
+                    }
+                    catch (JsonReaderException)
+                    {
+                        // Error is in bad format, return raw
+                        reterr = new DevCenterErrorReturn()
+                        {
+                            HttpErrorCode = (int)infoResult.StatusCode,
+                            StatusCode = infoResult.StatusCode.ToString("D") + " " + infoResult.StatusCode.ToString(),
+                            Message = content
+                        };
+                    }
+
+                    // reterr can be null when there is HTTP error
+                    if (reterr == null)
+                    {
+                        reterr = new DevCenterErrorReturn()
+                        {
+                            HttpErrorCode = (int)infoResult.StatusCode,
+                            StatusCode = infoResult.StatusCode.ToString("D") + " " + infoResult.StatusCode.ToString(),
+                            Message = infoResult.ReasonPhrase
+                        };
+                    }
+
+                    // Retry on the following 'infrastructure' issues
+                    // 502 BadGateway
+                    if (infoResult.StatusCode != System.Net.HttpStatusCode.BadGateway)
+                    {
+                        break;
+                    }
+                    await Task.Delay(new Random().Next(1000, 10000));
                 }
 
                 if (reterr.Error != null)
@@ -145,6 +155,7 @@ namespace SurfaceDevCenterManager.DevCenterApi
 
                 return new DevCenterErrorDetails
                 {
+                    HttpErrorCode = reterr.HttpErrorCode,
                     Code = reterr.StatusCode,
                     Message = reterr.Message
                 };
@@ -311,6 +322,25 @@ namespace SurfaceDevCenterManager.DevCenterApi
                     error == null
                 }
             };
+
+            if ((error.HttpErrorCode == (int)System.Net.HttpStatusCode.BadGateway) &&
+                (string.Compare(error.Code, "requestInvalidForCurrentState", true) == 0)
+                )
+            {
+                //  Communication issue likely caused the submission to already be done.  Check.
+                DevCenterResponse<Submission> SubmissionStatus = await GetSubmission(productId, submissionId);
+                if (SubmissionStatus.Error == null)
+                {
+                    Submission s = SubmissionStatus.ReturnValue[0];
+                    if (string.Compare(s.CommitStatus, "commitComplete", true) == 0)
+                    {
+                        //Actually did commit
+                        ret.Error = null;
+                        ret.ReturnValue = new List<bool>() { true };
+                    }
+                }
+            }
+
             return ret;
         }
 

--- a/SurfaceDevCenterManager/DevCenterApi/DevCenterHandler.cs
+++ b/SurfaceDevCenterManager/DevCenterApi/DevCenterHandler.cs
@@ -323,20 +323,23 @@ namespace SurfaceDevCenterManager.DevCenterApi
                 }
             };
 
-            if ((error.HttpErrorCode == (int)System.Net.HttpStatusCode.BadGateway) &&
-                (string.Compare(error.Code, "requestInvalidForCurrentState", true) == 0)
-                )
+            if (error != null)
             {
-                //  Communication issue likely caused the submission to already be done.  Check.
-                DevCenterResponse<Submission> SubmissionStatus = await GetSubmission(productId, submissionId);
-                if (SubmissionStatus.Error == null)
+                if ((error.HttpErrorCode == (int)System.Net.HttpStatusCode.BadGateway) &&
+                    (string.Compare(error.Code, "requestInvalidForCurrentState", true) == 0)
+                    )
                 {
-                    Submission s = SubmissionStatus.ReturnValue[0];
-                    if (string.Compare(s.CommitStatus, "commitComplete", true) == 0)
+                    //  Communication issue likely caused the submission to already be done.  Check.
+                    DevCenterResponse<Submission> SubmissionStatus = await GetSubmission(productId, submissionId);
+                    if (SubmissionStatus.Error == null)
                     {
-                        //Actually did commit
-                        ret.Error = null;
-                        ret.ReturnValue = new List<bool>() { true };
+                        Submission s = SubmissionStatus.ReturnValue[0];
+                        if (string.Compare(s.CommitStatus, "commitComplete", true) == 0)
+                        {
+                            //Actually did commit
+                            ret.Error = null;
+                            ret.ReturnValue = new List<bool>() { true };
+                        }
                     }
                 }
             }

--- a/SurfaceDevCenterManager/DevCenterApi/DevCenterHandler.cs
+++ b/SurfaceDevCenterManager/DevCenterApi/DevCenterHandler.cs
@@ -24,11 +24,11 @@ namespace SurfaceDevCenterManager.DevCenterApi
         /// Creates a new DevCenterHandler using the provided credentials
         /// </summary>
         /// <param name="credentials">Authorization credentials for HWDC</param>
-        public DevCenterHandler(AuthorizationHandlerCredentials credentials, int HttpTimeoutSeconds)
+        public DevCenterHandler(AuthorizationHandlerCredentials credentials, uint httpTimeoutSeconds)
         {
             AuthCredentials = credentials;
-            AuthHandler = new AuthorizationHandler(AuthCredentials, HttpTimeoutSeconds);
-            HttpTimeout = TimeSpan.FromSeconds(HttpTimeoutSeconds);
+            AuthHandler = new AuthorizationHandler(AuthCredentials, httpTimeoutSeconds);
+            HttpTimeout = TimeSpan.FromSeconds(httpTimeoutSeconds);
         }
 
         private string GetDevCenterBaseUrl()

--- a/SurfaceDevCenterManager/Program.cs
+++ b/SurfaceDevCenterManager/Program.cs
@@ -42,6 +42,7 @@ namespace SurfaceDevCenterManager
     internal class Program
     {
         private static int verbosity;
+        private const int DEFAULT_TIMEOUT = 5 * 60;
 
         private static int Main(string[] args)
         {
@@ -92,6 +93,8 @@ namespace SurfaceDevCenterManager
             int OverrideServer = 0;
             string CredentialsOption = null;
             string AADAuthenticationOption = null;
+            string TimeoutOption = null;
+            int HttpTimeout = DEFAULT_TIMEOUT;
 
             OptionSet p = new OptionSet() {
                 { "c|create=",         "Path to json file with configuration to create", v => CreateOption = v },
@@ -113,6 +116,7 @@ namespace SurfaceDevCenterManager
                 { "server=",           "Specify target DevCenter server from CredSelect enum", v => OverrideServer = int.Parse(v)   },
                 { "creds=",            "Option to specify app credentials.  Options: FileOnly, AADOnly, AADThenFile (Default)", v => CredentialsOption = v },
                 { "aad=",              "Option to specify AAD auth behavior.  Options: Never (Default), Prompt, Always, RefreshSession, SelectAccount", v => AADAuthenticationOption = v },
+                { "t|timeout=",        $"Adjust the timeout for HTTP requests to specified seconds.  Default:{DEFAULT_TIMEOUT} seconds", v => TimeoutOption = v  },
                 { "?",                 "Show this message and exit", v => show_help = v != null },
             };
 
@@ -149,7 +153,6 @@ namespace SurfaceDevCenterManager
                 ErrorParsingOptions("OverrideServer invalid - " + OverrideServer);
                 return ErrorCodes.OVERRIDE_SERVER_INVALID;
             }
-            DevCenterHandler api = new DevCenterHandler(myCreds[OverrideServer]);
 
             if (CreateOption != null && (!File.Exists(CreateOption)))
             {
@@ -163,6 +166,21 @@ namespace SurfaceDevCenterManager
                 ErrorParsingOptions("ListOption invalid - " + ListOption);
                 return ErrorCodes.LIST_INVALID_OPTION;
             }
+
+            if (TimeoutOption != null)
+            {
+                if (int.TryParse(TimeoutOption, out int inputParse))
+                {
+                    HttpTimeout = inputParse;
+                    Console.WriteLine($"> HttpTimeout: {HttpTimeout} seconds");
+                }
+                else
+                {
+                    Console.WriteLine($"> HttpTimeout: Invalid value {TimeoutOption}, using default timeout");
+                }
+            }
+
+            DevCenterHandler api = new DevCenterHandler(myCreds[OverrideServer], HttpTimeout);
 
             if (CreateOption != null)
             {

--- a/SurfaceDevCenterManager/Program.cs
+++ b/SurfaceDevCenterManager/Program.cs
@@ -42,7 +42,7 @@ namespace SurfaceDevCenterManager
     internal class Program
     {
         private static int verbosity;
-        private const int DEFAULT_TIMEOUT = 5 * 60;
+        private const uint DEFAULT_TIMEOUT = 5 * 60;
 
         private static int Main(string[] args)
         {
@@ -94,7 +94,7 @@ namespace SurfaceDevCenterManager
             string CredentialsOption = null;
             string AADAuthenticationOption = null;
             string TimeoutOption = null;
-            int HttpTimeout = DEFAULT_TIMEOUT;
+            uint HttpTimeout = DEFAULT_TIMEOUT;
 
             OptionSet p = new OptionSet() {
                 { "c|create=",         "Path to json file with configuration to create", v => CreateOption = v },
@@ -169,7 +169,7 @@ namespace SurfaceDevCenterManager
 
             if (TimeoutOption != null)
             {
-                if (int.TryParse(TimeoutOption, out int inputParse))
+                if (uint.TryParse(TimeoutOption, out uint inputParse))
                 {
                     HttpTimeout = inputParse;
                     Console.WriteLine($"> HttpTimeout: {HttpTimeout} seconds");

--- a/SurfaceDevCenterManager/Utility/AuthorizationHandler.cs
+++ b/SurfaceDevCenterManager/Utility/AuthorizationHandler.cs
@@ -24,6 +24,7 @@ namespace SurfaceDevCenterManager.Utility
     {
         private string _AccessToken;
         private readonly AuthorizationHandlerCredentials AuthCredentials;
+        private readonly TimeSpan HttpTimeout;
 
         private const int MAX_RETRIES = 10;
 
@@ -31,11 +32,12 @@ namespace SurfaceDevCenterManager.Utility
         /// Handles OAuth Tokens for HTTP request to Microsoft Hardware Dev Center
         /// </summary>
         /// <param name="credentials">The set of credentials to use for the token acquitisiton</param>
-        public AuthorizationHandler(AuthorizationHandlerCredentials credentials)
+        public AuthorizationHandler(AuthorizationHandlerCredentials credentials, int HttpTimeoutSeconds)
         {
             _AccessToken = null;
             AuthCredentials = credentials;
             InnerHandler = new HttpClientHandler();
+            HttpTimeout = TimeSpan.FromSeconds(HttpTimeoutSeconds);
         }
 
         /// <summary>
@@ -121,7 +123,7 @@ namespace SurfaceDevCenterManager.Utility
 
             using (HttpClient client = new HttpClient())
             {
-                client.Timeout = TimeSpan.FromSeconds(120);
+                client.Timeout = HttpTimeout;
                 Uri restApi = new Uri(DevCenterTokenUrl);
 
                 StringContent postcontent = new StringContent("grant_type=client_credentials" +

--- a/SurfaceDevCenterManager/Utility/AuthorizationHandler.cs
+++ b/SurfaceDevCenterManager/Utility/AuthorizationHandler.cs
@@ -32,12 +32,12 @@ namespace SurfaceDevCenterManager.Utility
         /// Handles OAuth Tokens for HTTP request to Microsoft Hardware Dev Center
         /// </summary>
         /// <param name="credentials">The set of credentials to use for the token acquitisiton</param>
-        public AuthorizationHandler(AuthorizationHandlerCredentials credentials, int HttpTimeoutSeconds)
+        public AuthorizationHandler(AuthorizationHandlerCredentials credentials, uint httpTimeoutSeconds)
         {
             _AccessToken = null;
             AuthCredentials = credentials;
             InnerHandler = new HttpClientHandler();
-            HttpTimeout = TimeSpan.FromSeconds(HttpTimeoutSeconds);
+            HttpTimeout = TimeSpan.FromSeconds(httpTimeoutSeconds);
         }
 
         /// <summary>


### PR DESCRIPTION
- Make the timeout for http requests configurable and default now to 5 minutes
- Add reporting up of http error code numbers and send up 'error pages' generated if they do not look like valid json errors from HDC
- Add retry logic for commit that handles a commit that succeeded but failed to report correctly