### PR TITLE
Fix for Submission ID parsing issue

### DIFF
--- a/Scripts/Attestation.ps1
+++ b/Scripts/Attestation.ps1
@@ -115,7 +115,7 @@ $json | ConvertTo-Json | Out-File -Encoding ASCII -FilePath "CreateSubmissionAtt
 Write-Output "    * Submit"
 $output = & $SCDM -create CreateSubmissionAttest.json -productid $SDCM_PID
 
-if (-not ([string]$output -match "---- Submission Created: (\d+)")) {
+if (-not ([string]$output -match "---- Submission: (\d+)")) {
     Write-Output "Did not find submission ID"
     Write-Output $output
     return -1

--- a/Scripts/HLKx.ps1
+++ b/Scripts/HLKx.ps1
@@ -115,7 +115,7 @@ $json | ConvertTo-Json | Out-File -Encoding ASCII -FilePath "CreateSubmissionHLK
 Write-Output "    * Submit"
 $output = & $SCDM -create CreateSubmissionHLK.json -productid $SDCM_PID
 
-if (-not ([string]$output -match "---- Submission Created: (\d+)")) {
+if (-not ([string]$output -match "---- Submission: (\d+)")) {
     Write-Output "Did not find submission ID"
     Write-Output $output
     return -1


### PR DESCRIPTION
SDCM executable returns the string "Submission:" instead of "Submission Created:" when communicating with the online service. Powershell scripts was changed to reflect it.