### PR TITLE
Additional Error Handling and Tracing for failures

### DIFF
--- a/SurfaceDevCenterManager/DevCenterApi/DevCenterErrorDetails.cs
+++ b/SurfaceDevCenterManager/DevCenterApi/DevCenterErrorDetails.cs
@@ -17,10 +17,24 @@ namespace SurfaceDevCenterManager.DevCenterApi
         public string Message { get; set; }
 
         [JsonProperty("validationErrors")]
-        public List<DevCenterErrorValidationErrorEntry> ValidationErrors;
+        public List<DevCenterErrorValidationErrorEntry> ValidationErrors { get; set; }
 
         [JsonProperty("httpErrorCode")]
         public int HttpErrorCode { get; set; }
+
+        public DevCenterErrorTrace Trace;
+    }
+
+    public class DevCenterErrorTrace
+    {
+        [JsonProperty("requestId")]
+        public string RequestId { get; set; }
+        [JsonProperty("url")]
+        public string Url { get; set; }
+        [JsonProperty("content")]
+        public string Content { get; set; }
+        [JsonProperty("method")]
+        public string Method { get; set; }
     }
 
     public class DevCenterErrorValidationErrorEntry

--- a/SurfaceDevCenterManager/SurfaceDevCenterManager.csproj
+++ b/SurfaceDevCenterManager/SurfaceDevCenterManager.csproj
@@ -117,13 +117,13 @@
       <Version>5.8.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory">
-      <Version>4.5.0</Version>
+      <Version>5.0.5</Version>
     </PackageReference>
     <PackageReference Include="Mono.Options">
       <Version>5.3.0.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.1</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="System.ComponentModel.EventBasedAsync">
       <Version>4.3.0</Version>


### PR DESCRIPTION
- Update Nuget libraries
- Add MS-CorrelationId and MS-RequestId headers to help with tracing issues
- Add more printouts on error including the CorrelationId and RequestId
- Update wait logic to complete when a 'signedPackage' is ready instead of looking for specific string states
