### PR TITLE
Add support for "ENVOnly" command line credential option.

### DIFF
--- a/SurfaceDevCenterManager.sln
+++ b/SurfaceDevCenterManager.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.2005
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30517.126
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SurfaceDevCenterManager", "SurfaceDevCenterManager\SurfaceDevCenterManager.csproj", "{6D5FB1F6-29EB-49E4-9B10-CB60B30265F2}"
 EndProject

--- a/SurfaceDevCenterManager/Program.cs
+++ b/SurfaceDevCenterManager/Program.cs
@@ -133,7 +133,7 @@ namespace SurfaceDevCenterManager
                 { "createmetadata",    "Requeset metadata creation for older submissions", v => CreateMetaData = true },
                 { "a|audience",        "List Audiences", v => AudienceOption = true },
                 { "server=",           "Specify target DevCenter server from CredSelect enum", v => { OverrideServer = int.Parse(v); OverrideServerPresent = true; }    },
-                { "creds=",            "Option to specify app credentials.  Options: FileOnly, AADOnly, AADThenFile (Default)", v => CredentialsOption = v },
+                { "creds=",            "Option to specify app credentials.  Options: ENVOnly, FileOnly, AADOnly, AADThenFile (Default)", v => CredentialsOption = v },
                 { "aad=",              "Option to specify AAD auth behavior.  Options: Never (Default), Prompt, Always, RefreshSession, SelectAccount", v => AADAuthenticationOption = v },
                 { "t|timeout=",        $"Adjust the timeout for HTTP requests to specified seconds.  Default:{DEFAULT_TIMEOUT} seconds", v => TimeoutOption = v  },
                 { "translate",         "Translate the given publisherid, productid and submissionid from a partner to the values visible in your HDC account", v => TranslateOption = true},

--- a/SurfaceDevCenterManager/Utility/DevCenterCredentialsHandler.cs
+++ b/SurfaceDevCenterManager/Utility/DevCenterCredentialsHandler.cs
@@ -94,6 +94,31 @@ namespace SurfaceDevCenterManager.Utility
             }
             CredentialsOption = CredentialsOption.ToLowerInvariant();
 
+            // Check environment variable option
+            if (CredentialsOption.CompareTo("envonly") == 0)
+            {
+                try
+                {
+                    myCreds = new List<AuthorizationHandlerCredentials>();
+
+                    myCreds.Add(new AuthorizationHandlerCredentials()
+                    {
+                        TenantId = Environment.GetEnvironmentVariable("SDCM_CREDS_TENANTID"),
+                        ClientId = Environment.GetEnvironmentVariable("SDCM_CREDS_CLIENTID"),
+                        Key = Environment.GetEnvironmentVariable("SDCM_CREDS_KEY"),
+                        Url = new Uri(Environment.GetEnvironmentVariable("SDCM_CREDS_URL"), UriKind.Absolute),
+                        UrlPrefix = new Uri(Environment.GetEnvironmentVariable("SDCM_CREDS_URLPREFIX"), UriKind.Relative)
+                    });
+
+                    return myCreds;
+                }
+                catch (Exception)
+                {
+                    Console.WriteLine("Missing or invalid environment variables: SDCM_CREDS_TENANTID, SDCM_CREDS_CLIENTID, SDCM_CREDS_KEY, SDCM_CREDS_URL, SDCM_CREDS_URLPREFIX");
+                    return null;
+                }
+            }
+
             if ((CredentialsOption.CompareTo("aadonly") == 0) || (CredentialsOption.CompareTo("aadthenfile") == 0))
             {
                 myCreds = await GetWebApiCreds(AADAuthenticationOption);


### PR DESCRIPTION
Add support for using environment variables to set credential information.  This option is intended to be used for Azure DevOps build automation.