### PR TITLE
Update dependency packages, Improve Trace handling

### DIFF
--- a/SurfaceDevCenterManager/Program.cs
+++ b/SurfaceDevCenterManager/Program.cs
@@ -1190,13 +1190,12 @@ namespace SurfaceDevCenterManager
                 }
             }
 
-            Console.WriteLine("Correlation Id: {0}", CorrelationId.ToString());
             if (error.Trace != null)
             {
-                Console.WriteLine("Request Id:     {0}", error.Trace.RequestId);
-                Console.WriteLine("Method:         {0}", error.Trace.Method);
-                Console.WriteLine("Url:            {0}", error.Trace.Url);
-                Console.WriteLine("Content:        {0}", error.Trace.Content);
+                Console.WriteLine("Request Id:     {0}", error.Trace.RequestId ?? "");
+                Console.WriteLine("Method:         {0}", error.Trace.Method ?? "" );
+                Console.WriteLine("Url:            {0}", error.Trace.Url ?? "");
+                Console.WriteLine("Content:        {0}", error.Trace.Content ?? "");
             }
         }
 

--- a/SurfaceDevCenterManager/SurfaceDevCenterManager.csproj
+++ b/SurfaceDevCenterManager/SurfaceDevCenterManager.csproj
@@ -92,25 +92,25 @@
       <Version>3.0.5</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Data.Edm">
-      <Version>5.8.4</Version>
+      <Version>5.8.5</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Data.OData">
-      <Version>5.8.4</Version>
+      <Version>5.8.5</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Data.Services.Client">
-      <Version>5.8.4</Version>
+      <Version>5.8.5</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Devices.HardwareDevCenterManager">
-      <Version>2.2.7</Version>
+      <Version>2.2.13</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory">
-      <Version>5.2.8</Version>
+      <Version>5.3.0</Version>
     </PackageReference>
     <PackageReference Include="Mono.Options">
       <Version>6.12.0.148</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
+      <Version>13.0.2</Version>
     </PackageReference>
     <PackageReference Include="System.ComponentModel.EventBasedAsync">
       <Version>4.3.0</Version>
@@ -125,7 +125,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Spatial">
-      <Version>5.8.4</Version>
+      <Version>5.8.5</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
## Why
Dependency packages were outdated.
`DevCenterErrorDetails.Trace` was causing field not found exception.

## What Changed
Following packages were update:
`Microsoft.Data.Edm`
`Microsoft.Data.OData`
`Microsoft.Data.Services.Client`
`Microsoft.Devices.HardwareDevCenterManager`
`Microsoft.IdentityModel.Clients.ActiveDirectory`
`Newtonsoft.Json`
`System.Spatial`

## Notes
Closes #36 
Closes #45 