### PR TITLE
Update scripts create objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,19 @@ Surface Dev Center Manager (SDCM) is a tool that utilizes the REST APIs made ava
     "createProduct": {
         "productName": "ProductName_HLK",
         "testHarness": "HLK",
-        "selectedProductTypes": { "windows_v100_RS4": "Unclassified" },
-        "requestedSignatures": [ "WINDOWS_v100_X64_RS4_FULL" ],
         "announcementDate": "2023-01-01T00:00:00",
-        "deviceType": "external",
-        "deviceMetaDataIds": null,
+        "deviceMetadataIds": null,
         "firmwareVersion": "0",
+        "deviceType": "external",
         "isTestSign": false,
-        "markettingNames": null,
+        "isFlightSign": false,
+        "marketingNames": null,
+        "selectedProductTypes": {
+            "windows_v100_RS4": "Unclassified"
+        },
+        "requestedSignatures": [
+            "WINDOWS_v100_X64_RS4_FULL"
+        ],
         "additionalAttributes": null
     }
 }
@@ -69,6 +74,7 @@ Surface Dev Center Manager (SDCM) is a tool that utilizes the REST APIs made ava
             "visibleToAccounts": [],
             "isAutoInstallDuringOSUpgrade": true,
             "isAutoInstallOnApplicableSystems": true,
+            "manualAcquisition": false,
             "isDisclosureRestricted": true,
             "publishToWindows10s": false,
             "additionalInfoForMsApproval": {
@@ -95,9 +101,15 @@ Surface Dev Center Manager (SDCM) is a tool that utilizes the REST APIs made ava
             ],
             "chids": [
                 {
-                    "chid": "guid"
+                    "chid": "guid",
+                    "distributionState": "pendingAdd"
                 }
-            ]
+            ],
+            "restrictedToAudiences": [],
+            "inServicePublishInfo": {
+                "flooring": "",
+                "ceiling": ""
+            }
         },
         "name": "ProductName_HLK_ShippingLabel",
         "destination": "windowsUpdate"

--- a/Scripts/Attestation.ps1
+++ b/Scripts/Attestation.ps1
@@ -39,7 +39,7 @@ trap {
   Write-Output "----- TRAP ----"
   Write-Output "Unhandled Exception: $($_.Exception.GetType().Name)"
   Write-Output $_.Exception
-  $_ | Format-List -Force 
+  $_ | Format-List -Force
 }
 
 ###################################################################################################
@@ -69,12 +69,12 @@ $CreateProductForAttestationJson = @"
     "productName": "$ProductName`_Attestation",
     "testHarness": "Attestation",
     "announcementDate": "2018-04-01T00:00:00",
-    "deviceMetaDataIds": null,
+    "deviceMetadataIds": null,
     "firmwareVersion": "0",
     "deviceType": "external",
     "isTestSign": false,
     "isFlightSign": false,
-    "markettingNames": null,
+    "marketingNames": null,
     "selectedProductTypes": { "windows_v100_RS4": "Unclassified" },
     "requestedSignatures": [ "WINDOWS_v100_X64_RS4_FULL" ],
     "additionalAttributes": null

--- a/Scripts/HLKx.ps1
+++ b/Scripts/HLKx.ps1
@@ -39,7 +39,7 @@ trap {
   Write-Output "----- TRAP ----"
   Write-Output "Unhandled Exception: $($_.Exception.GetType().Name)"
   Write-Output $_.Exception
-  $_ | Format-List -Force 
+  $_ | Format-List -Force
 }
 
 ###################################################################################################
@@ -69,12 +69,12 @@ $CreateProductForHLKxJson = @"
     "productName": "$ProductName`_HLK",
     "testHarness": "HLK",
     "announcementDate": "2018-04-01T00:00:00",
-    "deviceMetaDataIds": null,
+    "deviceMetadataIds": null,
     "firmwareVersion": "0",
     "deviceType": "external",
     "isTestSign": false,
     "isFlightSign": false,
-    "markettingNames": null,
+    "marketingNames": null,
     "selectedProductTypes": { "windows_v100_RS4": "Unclassified" },
     "requestedSignatures": [ "WINDOWS_v100_X64_RS4_FULL" ],
     "additionalAttributes": null

--- a/Scripts/ShippingLabel.ps1
+++ b/Scripts/ShippingLabel.ps1
@@ -60,7 +60,7 @@ trap {
   Write-Output "----- TRAP ----"
   Write-Output "Unhandled Exception: $($_.Exception.GetType().Name)"
   Write-Output $_.Exception
-  $_ | Format-List -Force 
+  $_ | Format-List -Force
 }
 
 ###################################################################################################
@@ -131,8 +131,8 @@ $CreateShippingLabelJson = @"
         "ceiling": $Ceiling
       }
     },
-      "name": "$ProductName`_ShippingLabel",
-      "destination": "windowsUpdate"
+    "name": "$ProductName`_ShippingLabel",
+    "destination": "windowsUpdate"
   }
 }
 "@


### PR DESCRIPTION
# Why
`Attestation.ps1`, `HLKx.ps1`, and `ShippingLabel.ps1` files and readme sections were out of sync with the current Microsoft hardware dashboard API documentation.

# What Changed
1. Updated `Attestation.ps1` and `HLKx.ps1` create product object
- correct spelling for `deviceMetadataIds` and `marketingNames`

1. Update `ShippingLabel.ps1`
- correct object indentation

1. Update README with changes above and reflect what is displayed in hardware dashboard API documentation
 
# Notes
Closes #43