### PR TITLE
Update package references

### DIFF
--- a/SurfaceDevCenterManager/SurfaceDevCenterManager.csproj
+++ b/SurfaceDevCenterManager/SurfaceDevCenterManager.csproj
@@ -88,20 +88,17 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.KeyVault.Core">
-      <Version>3.0.5</Version>
+    <PackageReference Include="Azure.Security.KeyVault.Keys">
+      <Version>4.6.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Data.Edm">
-      <Version>5.8.5</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Data.OData">
       <Version>5.8.5</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Data.Services.Client">
       <Version>5.8.5</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Devices.HardwareDevCenterManager">
-      <Version>3.0.12</Version>
+      <Version>3.0.13</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory">
       <Version>5.3.0</Version>


### PR DESCRIPTION
Update to latest packages
- `Microsoft.Devices.HardwareDevCenterManager` `3.0.12` => `3.0.13`
- `Microsoft.Azure.KeyVault.Core` `3.0.5` => `Azure.Security.KeyVault.Keys` `4.6.0`

The `Microsoft.Devices.HardwareDevCenterManager` `3.0.13` includes required update for `BlobStorageHandler`.

Fixes Issue #57 